### PR TITLE
[초기세팅] GlobalStyle 폰트 사이즈 62.5%로 수정 및 theme 설정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,14 @@
 import GlobalStyle from './styles/GlobalStyle';
+import { ThemeProvider } from 'styled-components';
+import theme from './styles/theme';
 
 function App() {
   return (
     <div>
-      <GlobalStyle />
-      <div>This is Test PR Branch</div>
+      <ThemeProvider theme={theme}>
+        <GlobalStyle />
+        <div>This is Test PR Branch</div>
+      </ThemeProvider>
     </div>
   );
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,6 +2,5 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './styles/font.css';
-import './styles/theme.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -6,7 +6,7 @@ const GlobalStyle = createGlobalStyle`
     margin: 0;
     font-family: "Pretendard", "Noto Sans", "sans-serif";
     word-break: keep-all;
-    font-size: 10px;
+    font-size: 62.5%;
   }
 
   html, body, div, span, applet, object, iframe,

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -1,0 +1,135 @@
+import { css } from 'styled-components';
+
+const theme = Object.freeze({
+  color: {
+    //회사별 대표 색
+    ce: '#8CC747',
+    carone: '#F6B436',
+    sg: '#00B8D6',
+    total: '#217A54',
+    si: '#004686',
+
+    //Gray
+    mainGray: '#3E3E43',
+    deepGray: '#666666',
+    lightGray: '#C7C7C7',
+
+    black: '#202020',
+    white: '#FFFFFF',
+  },
+
+  breakpoints: {
+    tablet: 768,
+    desktop: 1024,
+    widescreen: 1440,
+  },
+
+  font: {
+    FONT60B: css`
+      font-size: 6rem;
+      font-weight: 700;
+    `,
+    FONT45B: css`
+      font-size: 4.5rem;
+      font-weight: 700;
+    `,
+    FONT45SB: css`
+      font-size: 4.5rem;
+      font-weight: 600;
+    `,
+    FONT36B: css`
+      font-size: 3.6rem;
+      font-weight: 700;
+    `,
+    FONT32B: css`
+      font-size: 3.2rem;
+      font-weight: 700;
+    `,
+    FONT28B: css`
+      font-size: 2.8rem;
+      font-weight: 700;
+    `,
+    FONT28SB: css`
+      font-size: 2.8rem;
+      font-weight: 600;
+    `,
+    FONT28: css`
+      font-size: 2.8rem;
+      font-weight: 400;
+    `,
+    FONT24B: css`
+      font-size: 2.4rem;
+      font-weight: 700;
+    `,
+    FONT24SB: css`
+      font-size: 2.4rem;
+      font-weight: 600;
+    `,
+    FONT24: css`
+      font-size: 2.4rem;
+      font-weight: 400;
+    `,
+    FONT20B: css`
+      font-size: 2rem;
+      font-weight: 700;
+    `,
+    FONT20SB: css`
+      font-size: 2rem;
+      font-weight: 600;
+    `,
+    FONT20: css`
+      font-size: 2rem;
+      font-weight: 400;
+    `,
+    FONT20L: css`
+      font-size: 2rem;
+      font-weight: 300;
+    `,
+    FONT18B: css`
+      font-size: 1.8rem;
+      font-weight: 700;
+    `,
+    FONT18SB: css`
+      font-size: 1.8rem;
+      font-weight: 600;
+    `,
+    FONT18: css`
+      font-size: 1.8rem;
+      font-weight: 400;
+    `,
+    FONT18L: css`
+      font-size: 1.8rem;
+      font-weight: 300;
+    `,
+    FONT16B: css`
+      font-size: 1.6rem;
+      font-weight: 700;
+    `,
+    FONT16SB: css`
+      font-size: 1.6rem;
+      font-weight: 600;
+    `,
+    FONT16: css`
+      font-size: 1.6rem;
+      font-weight: 400;
+    `,
+    FONT14B: css`
+      font-size: 1.4rem;
+      font-weight: 700;
+    `,
+    FONT14: css`
+      font-size: 1.4rem;
+      font-weight: 400;
+    `,
+    FONT12SB: css`
+      font-size: 1.2rem;
+      font-weight: 600;
+    `,
+    FONT12: css`
+      font-size: 1.2rem;
+      font-weight: 400;
+    `,
+  },
+});
+
+export default theme;


### PR DESCRIPTION
## 🚀 작업 내용

- GlobalStyle.js font 사이즈 62.5%로 수정
- theme.js 파일 생성
- color, breakpoints, font 지정

## 📝 참고 사항

- theme 사용 방법 참고
<img width="374" alt="image" src="https://github.com/BoooostUp/carone/assets/80617716/c570321d-b4eb-4164-9881-cf6cc27bed27">


## 🖼️ 스크린샷

X

## 🚨 관련 이슈

X
