### PR TITLE
[컴포넌트] Root 페이지 수정, 로고와 인재채용 버튼 구현

### DIFF
--- a/src/components/RecruitButton.jsx
+++ b/src/components/RecruitButton.jsx
@@ -1,0 +1,3 @@
+const RecruitButton = () => {};
+
+export default RecruitButton;

--- a/src/components/RecruitButton.jsx
+++ b/src/components/RecruitButton.jsx
@@ -1,3 +1,29 @@
-const RecruitButton = () => {};
+import styled from 'styled-components';
+
+const RecruitButton = () => {
+  return (
+    <S.Container>
+      <S.ButtonText>인재 채용</S.ButtonText>
+    </S.Container>
+  );
+};
 
 export default RecruitButton;
+
+const S = {
+  Container: styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 11rem;
+    height: 5rem;
+    border-radius: 20px;
+    background-color: ${({ theme }) => theme.color.black};
+    cursor: pointer;
+  `,
+
+  ButtonText: styled.h3`
+    color: ${({ theme }) => theme.color.white};
+    ${({ theme }) => theme.font.FONT18B};
+  `,
+};

--- a/src/pages/Root.jsx
+++ b/src/pages/Root.jsx
@@ -49,9 +49,9 @@ const S = {
       left: 0;
       right: 0;
       bottom: 0;
-      background-color: ${({ $backgroundColor, hovered }) =>
-        hovered ? $backgroundColor : 'transparent'};
-      opacity: ${({ hovered }) => (hovered ? 0.3 : 0)};
+      opacity: 0.3;
+      display: ${({ $isHovered }) => ($isHovered ? 'block' : 'none')};
+      background-color: ${({ $backgroundColor }) => $backgroundColor};
     }
   `,
 
@@ -60,24 +60,24 @@ const S = {
     left: 50%;
     right: 50%;
     transform: translate(-50%);
-    display: ${({ $show }) => ($show ? 'flex' : 'none')};
     justify-content: center;
     align-items: center;
     gap: 3rem;
     width: 100%;
     height: 100%;
+    display: ${({ $isHovered }) => ($isHovered ? 'flex' : 'none')};
     color: ${({ theme }) => theme.color.white};
   `,
 
   CompanyName: styled.h2`
-    ${({ theme }) => theme.font.FONT36B}
     text-shadow: 0px 2px 4px black;
+    ${({ theme }) => theme.font.FONT36B}
   `,
 
   CompanyInfo: styled.p`
     white-space: pre-wrap;
-    ${({ theme }) => theme.font.FONT18B}
     text-shadow: 0px 2px 4px black;
+    ${({ theme }) => theme.font.FONT18B}
   `,
 
   Index: styled.span`
@@ -98,19 +98,18 @@ const S = {
       opacity: 0.8;
       border-top-left-radius: 70px;
       z-index: -1;
+      display: ${({ $isHovered }) => ($isHovered ? 'none' : 'block')};
       background-color: ${({ $backgroundColor }) => $backgroundColor};
-      visibility: ${({ $show }) => ($show ? 'hidden' : 'visible')};
     }
   `,
 
   IndexText: styled.h2`
-    display: flex;
+    height: 100%;
     justify-content: center;
     align-items: center;
-    height: 100%;
+    display: ${({ $isHovered }) => ($isHovered ? 'none' : 'flex')};
     color: ${({ theme }) => theme.color.white};
     ${({ theme }) => theme.font.FONT24B}
-    visibility: ${({ $show }) => ($show ? 'hidden' : 'visible')};
   `,
 };
 
@@ -124,21 +123,21 @@ const Root = () => {
         {ROOT.CELLS.map(({ id, cellImg, indexColor, name, description }) => (
           <S.Cell
             key={id}
+            $isHovered={hovered === id}
             $backgroundImage={cellImg}
             $backgroundColor={theme.color[indexColor]}
-            $hovered={hovered === id}
           >
-            <S.CompanyWrapper $show={hovered === id}>
+            <S.CompanyWrapper $isHovered={hovered === id}>
               <S.CompanyName>{name}</S.CompanyName>
               <S.CompanyInfo>{description}</S.CompanyInfo>
             </S.CompanyWrapper>
             <S.Index
+              $isHovered={hovered === id}
               $backgroundColor={theme.color[indexColor]}
-              $show={hovered === id}
               onMouseEnter={() => setHovered(id)}
               onMouseLeave={() => setHovered(null)}
             >
-              <S.IndexText $show={hovered === id}>{name}</S.IndexText>
+              <S.IndexText $isHovered={hovered === id}>{name}</S.IndexText>
             </S.Index>
           </S.Cell>
         ))}

--- a/src/pages/Root.jsx
+++ b/src/pages/Root.jsx
@@ -4,6 +4,43 @@ import logo from '../assets/icons/Logo.svg';
 import { ROOT } from '../constants/ROOT';
 import theme from '../styles/theme';
 
+const Root = () => {
+  const [hovered, setHovered] = useState(null);
+
+  return (
+    <S.Container>
+      <S.Header>
+        <S.Logo src={logo} />
+      </S.Header>
+      <S.CellWrapper>
+        {ROOT.CELLS.map(({ id, cellImg, indexColor, name, description }) => (
+          <S.Cell
+            key={id}
+            $isHovered={hovered === id}
+            $backgroundImage={cellImg}
+            $backgroundColor={theme.color[indexColor]}
+          >
+            <S.CompanyWrapper $isHovered={hovered === id}>
+              <S.CompanyName>{name}</S.CompanyName>
+              <S.CompanyInfo>{description}</S.CompanyInfo>
+            </S.CompanyWrapper>
+            <S.Index
+              $isHovered={hovered === id}
+              $backgroundColor={theme.color[indexColor]}
+              onMouseEnter={() => setHovered(id)}
+              onMouseLeave={() => setHovered(null)}
+            >
+              <S.IndexText $isHovered={hovered === id}>{name}</S.IndexText>
+            </S.Index>
+          </S.Cell>
+        ))}
+      </S.CellWrapper>
+    </S.Container>
+  );
+};
+
+export default Root;
+
 const S = {
   Container: styled.div`
     position: relative;
@@ -117,40 +154,3 @@ const S = {
     ${({ theme }) => theme.font.FONT24B}
   `,
 };
-
-const Root = () => {
-  const [hovered, setHovered] = useState(null);
-
-  return (
-    <S.Container>
-      <S.Header>
-        <S.Logo src={logo} />
-      </S.Header>
-      <S.CellWrapper>
-        {ROOT.CELLS.map(({ id, cellImg, indexColor, name, description }) => (
-          <S.Cell
-            key={id}
-            $isHovered={hovered === id}
-            $backgroundImage={cellImg}
-            $backgroundColor={theme.color[indexColor]}
-          >
-            <S.CompanyWrapper $isHovered={hovered === id}>
-              <S.CompanyName>{name}</S.CompanyName>
-              <S.CompanyInfo>{description}</S.CompanyInfo>
-            </S.CompanyWrapper>
-            <S.Index
-              $isHovered={hovered === id}
-              $backgroundColor={theme.color[indexColor]}
-              onMouseEnter={() => setHovered(id)}
-              onMouseLeave={() => setHovered(null)}
-            >
-              <S.IndexText $isHovered={hovered === id}>{name}</S.IndexText>
-            </S.Index>
-          </S.Cell>
-        ))}
-      </S.CellWrapper>
-    </S.Container>
-  );
-};
-
-export default Root;

--- a/src/pages/Root.jsx
+++ b/src/pages/Root.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import styled from 'styled-components';
+import logo from '../assets/icons/Logo.svg';
 import { ROOT } from '../constants/ROOT';
 import theme from '../styles/theme';
 
@@ -19,6 +20,10 @@ const S = {
     align-items: center;
     padding: 20px;
     z-index: 2;
+  `,
+
+  Logo: styled.img`
+    width: 10rem;
   `,
 
   CellWrapper: styled.section`
@@ -118,7 +123,9 @@ const Root = () => {
 
   return (
     <S.Container>
-      <S.Header>로고</S.Header>
+      <S.Header>
+        <S.Logo src={logo} />
+      </S.Header>
       <S.CellWrapper>
         {ROOT.CELLS.map(({ id, cellImg, indexColor, name, description }) => (
           <S.Cell

--- a/src/pages/Root.jsx
+++ b/src/pages/Root.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import styled from 'styled-components';
 import logo from '../assets/icons/Logo.svg';
+import RecruitButton from '../components/RecruitButton';
 import { ROOT } from '../constants/ROOT';
 import theme from '../styles/theme';
 
@@ -11,6 +12,7 @@ const Root = () => {
     <S.Container>
       <S.Header>
         <S.Logo src={logo} />
+        <RecruitButton />
       </S.Header>
       <S.CellWrapper>
         {ROOT.CELLS.map(({ id, cellImg, indexColor, name, description }) => (


### PR DESCRIPTION
## 🚀 작업 내용

- Index에 hover할 때 배경과 회사 설명이 렌더링 되도록 수정 구현
- 로고 적용
- 인재 채용 버튼 적용
- return 부분이 먼저 보이도록 스타일은 하단에 위치
- 애매한 네이밍을 명확하게 변경 (ex. show -> isHovered)

## 📝 참고 사항

- 인재 채용 버튼은 디자인만 완성해두었음

## 🖼️ 스크린샷

![image](https://github.com/BoooostUp/carone/assets/108844881/02f7ff28-290f-48bb-a9de-4b9eb5e910af)


## 🚨 관련 이슈

-
